### PR TITLE
WIP Always show entrar button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -105,6 +105,7 @@ section {
 }
 .intro a {
   color: #000;
+  margin-bottom: 10px;
   text-shadow: 0 0 4px rgba(255, 255, 255, 0.7);
 }
 
@@ -132,7 +133,6 @@ section {
   text-shadow: 0 0 3px rgba(0,0,0,0.9);
   background-color: rgba(0,0,0,.4);
   width: 100%;
-  height: 100%;
 }
 .intro .intro-content p {
   max-width: 65vmax;
@@ -142,6 +142,7 @@ section {
 }
 .intro .intro-content img {
   width: 300px;
+  height: 148px;
   margin-top: 30px;
   margin-bottom: 5vmin;
 }
@@ -193,7 +194,6 @@ p.caption {
 }
 .page-index {
   padding: 0;
-  overflow: hidden;
 }
 
 .page-capitulo1 .intro {

--- a/js/app.js
+++ b/js/app.js
@@ -1,11 +1,19 @@
 var $window;
 var $videos;
 var $intro;
+var $introContent;
 
 // Resize intro box
 var fitIntro = function(e) {
   var height = $window.height();
-  $intro.height(height);
+  // If .intro-content exists, get its height and include .logo 90px
+  var introContentHeight = $introContent.height() ? $introContent.height() + 90 : 0;
+
+  if (height > introContentHeight) {
+    $intro.height(height);
+  } else {
+    $intro.height(introContentHeight);
+  }
 }
 
 $(function() {
@@ -13,6 +21,7 @@ $(function() {
   $window = $(window);
   $videos = $('.video');
   $intro = $('.intro');
+  $introContent = $('.intro-content');
 
   // Behaviors
   $videos.fitVids();


### PR DESCRIPTION
### What is this?
My attempt to fix #9 

### What's the plan?
`.intro-content` was getting cut off by app.js when `$window.height()` was shorter than `.intro-content`. This code changes `fitIntro()` to [compare the heights](https://github.com/ichido/masde72/commit/b1455de105ced649c2572abf4a51155bba793317#diff-41d794d24ff042b1f9ac211fc3f9f951R4) of `.intro-content` and `$window` and use the larger.

This code challenges some assumptions:
* Because `.intro-content` is sometimes taller than the window, [scrolling is re-enabled](https://github.com/ichido/masde72/pull/20/files#diff-6a6a912d0c7b55b537768da778032849R195)
* In order to get an accurate `$('.intro-content').height()`, [remove its 100% height](https://github.com/ichido/masde72/compare/show-title-button?expand=1#diff-6a6a912d0c7b55b537768da778032849L135). However, this has a consequence.

### Code smell

Because `.intro-content` is no longer 100% height, sometimes it is shorter than `.intro` and its background-color does not cover the entire iframe.

![challenge](https://cloud.githubusercontent.com/assets/1087467/6320945/17acdfa6-baa1-11e4-8edc-71184c67ee79.png)

I think ideally there would be a background div behind `.intro-content` with 100% height for the grey screen, but this is tricky because the video has [absolute position](https://github.com/ichido/masde72/blob/master/css/style.css#L111-L125).

Another solution could let `.intro-content` keep its 100% height but make its contents smaller when its contents are taller than the window.