### PR TITLE
Add unveil.js

### DIFF
--- a/_masde72_base.html
+++ b/_masde72_base.html
@@ -13,6 +13,7 @@
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/fitvids/1.1.0/jquery.fitvids.min.js"></script>
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery-scrollTo/1.4.11/jquery.scrollTo.min.js"></script>
 <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery-localScroll/1.3.5/jquery.localScroll.min.js"></script>
+<script type="text/javascript" src="js/unveil.js"></script>
 <script type="text/javascript" src="js/app.js"></script>
 {% endblock %}
 

--- a/capitulo2.html
+++ b/capitulo2.html
@@ -57,15 +57,15 @@
 
         <div class="row photos">
           <div class="col-md-6">
-            <img src="img/cap2_funeraria1.jpg" class="img-responsive"/>
+            <img src="img/home_logo.png" data-src="img/cap2_funeraria1.jpg" class="img-responsive"/>
           </div>
           <div class="col-md-3">
-            <img src="img/cap2_funeraria2.jpg" class="img-responsive"/>
-            <img src="img/cap2_funeraria3.jpg" class="img-responsive"/>
+            <img src="img/home_logo.png" data-src="img/cap2_funeraria2.jpg" class="img-responsive"/>
+            <img src="img/home_logo.png" data-src="img/cap2_funeraria3.jpg" class="img-responsive"/>
           </div>
           <div class="col-md-3">
-            <img src="img/cap2_funeraria4.jpg" class="img-responsive"/>
-            <img src="img/cap2_funeraria5.jpg" class="img-responsive"/>
+            <img src="img/home_logo.png" data-src="img/cap2_funeraria4.jpg" class="img-responsive"/>
+            <img src="img/home_logo.png" data-src="img/cap2_funeraria5.jpg" class="img-responsive"/>
             <p class="caption">Guillermo Arias</p>
           </div>
         </div>
@@ -78,7 +78,7 @@
         <p>El 25 de agosto, 49 de los cuerpos se quedaron en la Base Naval. Incluso ahí, bajo el cuidado de las autoridades federales, los cadáveres permanecieron expuestos a la intemperie y apilados, unos sobre otros.</p>
       </div>
       <div class="col-md-4 photos">
-        <img src="img/cap2_naval.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_naval.jpg" class="img-responsive"/>
       </div>
     </div>
 
@@ -93,7 +93,7 @@
   <div class="container">
     <h2>Autopsias</h2>
       <h4>Fallas denunciadas por la CNDH</h4>
-        <img src="img/cap_2_autopsias.png" class="img-responsive">
+        <img src="img/home_logo.png" data-src="img/cap_2_autopsias.png" class="img-responsive">
   </div>
 </section>
 
@@ -126,7 +126,7 @@
               dejó asentada qué pertenencias correspondían a cuál cadaver.
               Las consecuencias pronto se dejaron ver.
           </p>
-        <img src="img/mapas-01.png" class="img-responsive">
+        <img src="img/img/home_logo.png" data-src="mapas-01.png" class="img-responsive">
       </div>
       <div class="col-md-3 map">
         <p> -Julian Sánchez Benítez
@@ -157,10 +157,10 @@
       </p>
     <div class="row photos">
       <div class="col-md-6">
-        <img src="img/cap2_honduras1.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_honduras1.jpg" class="img-responsive"/>
       </div>
       <div class="col-md-6">
-        <img src="img/cap2_honduras2.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_honduras2.jpg" class="img-responsive"/>
       </div>
     </div>
       <p> El 15 de septiembre, tras dos semanas de análisis, el canciller de Honduras
@@ -169,10 +169,10 @@
       </p>
     <div class="row photos">
       <div class="col-md-6">
-        <img src="img/cap2_honduras3.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_honduras3.jpg" class="img-responsive"/>
       </div>
       <div class="col-md-6">
-        <img src="img/cap2_honduras4.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_honduras4.jpg" class="img-responsive"/>
       </div>
     </div>
       <p> El otro cuerpo enviado por error a Tegucigalpa correspondía
@@ -190,7 +190,7 @@
       </p>
     <div class="row">
       <div class="col-md-8">
-        <img src="img/mapas-02.png" class="img-responsive">
+        <img src="img/img/home_logo.png" data-src="mapas-02.png" class="img-responsive">
       </div>
     </div>
 </section>
@@ -203,7 +203,7 @@
     <div class="row">
       <div class="col-md-8">
         <h4>31 de agosto de 2010</h4>
-        <img src="img/mapas-03.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-03.png" class="img-responsive"/>
       </div>
       <div class="col-md-4">
         <p> Los 56 cuerpos que el gobierno de Tamaulipas no pudo identificar,
@@ -232,7 +232,7 @@
     <div class="row">
       <div class="col-md-8">
         <h4>5 de septiembre de 2010</h4>
-        <img src="img/mapas-05.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-05.png" class="img-responsive"/>
          <p>Mirna del Carmen Solórzano Medrano, madre de Glenda Yaneira, está segura que no enterró a su hija. Ella desobedeció las indicaciones del  gobierno de su país y abrió el féretro que según contenía el cadáver de su hija: encontró un cuerpo lastimado, calcificado, que ella recuerda como “una momia blanca, sin pelo” y cuando le palparon los genitales, sintieron “un bulto”; sin embargo, pese a las dudas, procedió el ritual funerario por miedo a “haber desobedecido” a sus autoridades.</p>
       </div>
       <div class="col-md-3 map">
@@ -251,20 +251,20 @@
     </div>
     <div class="row photos">
       <div class="col-md-12">
-        <img src="img/cap2_salvador3.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_salvador3.jpg" class="img-responsive"/>
       </div>
     </div>
     <div class="row photos">
       <div class="col-md-6">
-        <img src="img/cap2_salvador1.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_salvador1.jpg" class="img-responsive"/>
       </div>
       <div class="col-md-3">
-        <img src="img/cap2_salvador2.jpg" class="img-responsive"/>
-        <img src="img/cap2_salvador4.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_salvador2.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_salvador4.jpg" class="img-responsive"/>
       </div>
       <div class="col-md-3">
-        <img src="img/cap2_salvador5.jpg" class="img-responsive"/>
-        <img src="img/cap2_salvador6.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_salvador5.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_salvador6.jpg" class="img-responsive"/>
       </div>
     </div>
   </div>
@@ -278,7 +278,7 @@
     <div class="row">
       <div class="col-md-8">
         <h4>24 de septiembre del 2010</h4>
-        <img src="img/mapas-06.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-06.png" class="img-responsive"/>
       </div>
       <div class="col-md-3 map">
           -Gilmar Augusto Morales Castillo
@@ -292,12 +292,12 @@
 
     <div class="row photos">
       <div class="col-md-4">
-        <img src="img/cap2_guatemala1.jpg" class="img-responsive"/>
-        <img src="img/cap2_guatemala2.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_guatemala1.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_guatemala2.jpg" class="img-responsive"/>
       </div>
       <div class="col-md-4">
-        <img src="img/cap2_guatemala3.jpg" class="img-responsive"/>
-        <img src="img/cap2_guatemala4.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_guatemala3.jpg" class="img-responsive"/>
+        <img src="img/home_logo.png" data-src="img/cap2_guatemala4.jpg" class="img-responsive"/>
       </div>
     </div>
   </div>
@@ -312,7 +312,7 @@
       <div class="col-md-8">
         <h4>5 de noviembre de 2010</h4>
         <p> La Comisión Nacional de Derechos Humanos de Mexico sitúa las siguientes devoluciones a Honduras: dos cuerpos el 23, un cuerpo el 25 y dos cuerpos el 28 de septiembre, pero el único vuelo con restos repatriados registrado por las autoridades de ese país salió el 5 de noviembre. En lugar de los cinco féretros contabilizados por la CNDH, Honduras reporta ocho:
-        <img src="img/mapas-07.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-07.png" class="img-responsive"/>
       </div>
       <div class="col-md-3 map">
         -Vicente Medina Lozano
@@ -331,7 +331,7 @@
       <div class="col-md-8">
         <h4>5 de noviembre de 2010</h4>
         <p> Ese mismo día también fueron retornados a su país, Guatemala, 8 cadaveres:</p>
-        <img src="img/mapas-08.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-08.png" class="img-responsive"/>
       </div>
       <div class="col-md-3 map">
         -Byron Mauricio Berdúo Agustín
@@ -357,7 +357,7 @@
     <div class="row">
       <div class="col-md-8">
         <h4>4 de octubre y 1 de noviembre de 2010</h4>
-        <img src="img/mapas-13.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-13.png" class="img-responsive"/>
       </div>
       <div class="col-md-3 map">
         -Juliard Aires Fernandes
@@ -372,7 +372,7 @@
     <div class="row">
       <div class="col-md-8">
         <h4>4 de octubre y 7 de diciembre de 2010</h4>
-        <img src="img/mapas-14.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-14.png" class="img-responsive"/>
       </div>
       <div class="col-md-3 map">
         -Telmo Leonidas Yupa Chimborazo
@@ -397,7 +397,7 @@
     <div class="row">
       <div class="col-md-8">
         <h4>10 de febrero de 2011</h4>
-        <img src="img/mapas-09.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-09.png" class="img-responsive"/>
       </div>
       <div class="col-md-3 map">
         -Christian Andrés Caguana Campos
@@ -415,7 +415,7 @@
     <div class="row">
       <div class="col-md-8">
         <h4>23 de marzo de 2011</h4>
-         <img src="img/mapas-10.png" class="img-responsive"/>
+         <img src="img/img/home_logo.png" data-src="mapas-10.png" class="img-responsive"/>
       </div>
       <div class="col-md-3 map">
         -Nancy Pineda
@@ -435,7 +435,7 @@
     <div class="row">
       <div class="col-md-8">
         <h4>8 de junio de 2011</h4>
-        <img src="img/mapas-11.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-11.png" class="img-responsive"/>
       </div>
       <div class="col-md-3 map">
         -Ankitkumar Bharatbai Patel
@@ -464,7 +464,7 @@
     <div class="row">
       <div class="col-md-8">
         <h4>20 de enero de 2012</h4>
-        <img src="img/mapas-14.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-14.png" class="img-responsive"/>
       </div>
       <div class="col-md-3 map">
           -Rosa Amelia Panza Quilli
@@ -487,7 +487,7 @@
         </p>
       </div>
       <div class="col-md-3 map">
-        <img src="img/mapas-12.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-12.png" class="img-responsive"/>
       </div>
     </div>
 
@@ -497,7 +497,7 @@
         </p>
       </div>
       <div class="col-md-3 map">
-        <img src="img/mapas-15.png" class="img-responsive"/>
+        <img src="img/img/home_logo.png" data-src="mapas-15.png" class="img-responsive"/>
       </div>
     </div>
 
@@ -507,7 +507,7 @@
         </p>
       </div>
       <div class="col-md-3 map">
-          <img src="img/mapas-16.png" class="img-responsive"/>
+          <img src="img/img/home_logo.png" data-src="mapas-16.png" class="img-responsive"/>
       </div>
     </div>
 </section>

--- a/capitulo4.html
+++ b/capitulo4.html
@@ -52,9 +52,9 @@
       </div>
       <div class="col-md-4 info">
         {% if persona.unknown_image %}
-        <img src="img/cap4_unknown.jpg" class="img-responsive">
+        <img src="img/home_logo.png" data-src="img/cap4_unknown.jpg" class="img-responsive">
         {% else %}
-        <img src="img/cap4_{{ persona.id }}.jpg" class="img-responsive">
+        <img src="img/home_logo.png" data-src="img/cap4_{{ persona.id }}.jpg" class="img-responsive">
         {% endif %}
       </div>
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -21,4 +21,5 @@ $(function() {
   $.localScroll({
     'duration': 500
   });
+  $("img").unveil(200);
 });

--- a/js/unveil.js
+++ b/js/unveil.js
@@ -1,0 +1,56 @@
+/**
+ * jQuery Unveil
+ * A very lightweight jQuery plugin to lazy load images
+ * http://luis-almeida.github.com/unveil
+ *
+ * Licensed under the MIT license.
+ * Copyright 2013 Luís Almeida
+ * https://github.com/luis-almeida
+ */
+
+;(function($) {
+
+  $.fn.unveil = function(threshold, callback) {
+
+    var $w = $(window),
+        th = threshold || 0,
+        retina = window.devicePixelRatio > 1,
+        attrib = retina? "data-src-retina" : "data-src",
+        images = this,
+        loaded;
+
+    this.one("unveil", function() {
+      var source = this.getAttribute(attrib);
+      source = source || this.getAttribute("data-src");
+      if (source) {
+        this.setAttribute("src", source);
+        if (typeof callback === "function") callback.call(this);
+      }
+    });
+
+    function unveil() {
+      var inview = images.filter(function() {
+        var $e = $(this);
+        if ($e.is(":hidden")) return;
+
+        var wt = $w.scrollTop(),
+            wb = wt + $w.height(),
+            et = $e.offset().top,
+            eb = et + $e.height();
+
+        return eb >= wt - th && et <= wb + th;
+      });
+
+      loaded = inview.trigger("unveil");
+      images = images.not(loaded);
+    }
+
+    $w.on("scroll.unveil resize.unveil lookup.unveil", unveil);
+
+    unveil();
+
+    return this;
+
+  };
+
+})(window.jQuery || window.Zepto);


### PR DESCRIPTION
Closes #15 

Adds [unveil](http://luis-almeida.github.io/unveil/) to capitulos 2 and 4 because they were the only chapters with multiple bulky images at the time of this PR.

Uses [home_logo.png](https://github.com/ichido/masde72/blob/master/img/home_logo.png) as the placeholder image until unveil loads the actual image, but the [200px](https://github.com/ichido/masde72/blob/7e45f9261fca5341a9f500ba1690044c722e228c/js/app.js#L24) buffer should prevent most users from seeing the placeholder.

### Todo
* Use for future credits pages?